### PR TITLE
HI-72 Use realpath root instead of document root

### DIFF
--- a/templates/magento2-vhost.conf.j2
+++ b/templates/magento2-vhost.conf.j2
@@ -81,7 +81,7 @@ server {
             fastcgi_connect_timeout 600s;
 
             fastcgi_index  index.php;
-            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+            fastcgi_param  SCRIPT_FILENAME  $realpath_root$fastcgi_script_name;
             include        fastcgi_params;
         }
 
@@ -102,7 +102,7 @@ server {
             fastcgi_split_path_info ^(/update/index.php)(/.+)$;
             fastcgi_pass   fastcgi_backend;
             fastcgi_index  index.php;
-            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+            fastcgi_param  SCRIPT_FILENAME  $realpath_root$fastcgi_script_name;
             fastcgi_param  PATH_INFO        $fastcgi_path_info;
             include        fastcgi_params;
         }
@@ -218,7 +218,7 @@ server {
         fastcgi_param  HTTPS         $is_https if_not_empty;
 
         fastcgi_index  index.php;
-        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+        fastcgi_param  SCRIPT_FILENAME  $realpath_root$fastcgi_script_name;
         include        fastcgi_params;
     }
   


### PR DESCRIPTION
This changes the location of the script to be be fully resolved so that PHP doesn't need to be restarted between deployments in order to clear the realpath cache.